### PR TITLE
Lazy load widgets in JupyterLab

### DIFF
--- a/js/src/plugin.ts
+++ b/js/src/plugin.ts
@@ -18,7 +18,6 @@ import {
   IJupyterWidgetRegistry,
 } from "@jupyter-widgets/base";
 
-import * as widgetExports from "./widget";
 
 import {
   MODULE_VERSION,
@@ -44,7 +43,7 @@ export default examplePlugin;
  */
 function activateWidgetExtension(app: Application<Widget>, registry: IJupyterWidgetRegistry): void {
   registry.registerWidget({
-    exports: widgetExports,
+    exports: async () => await import(/* webpackChunkName: "ipyregulartable" */ "./widget"),
     name: "ipyregulartable",
     version: MODULE_VERSION,
   });

--- a/js/tsconfig.json
+++ b/js/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop":true,
     "lib": ["es2015", "dom"],
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "./lib",
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "strict": true,
     "strictPropertyInitialization": false,
-    "target": "ES6",
+    "target": "es2015",
     "types": ["jest", "node"]
   },
   "include": [


### PR DESCRIPTION
This implements the change described in #24.

## references
- fixes #24

## code changes
- [x] wait to import widget implementation until a widget is requested
  - [x] use `esnext` modules instead of `commonjs`

## user-facing changes
- the "moon" animation should appear slightly more quickly
- jupyterlab 2 builds should complete more quickly/reliably (especially "production" builds with minification, and on windows/osx)
- there may be a slightly longer delay the first time a table widget is loaded
- after the widget is cached, there should be no noticeable difference

## backwards-incompatible changes
- probably none