### PR TITLE
Reduce CI burder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build Status
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   schedule:
     # run on sunday nights
@@ -14,8 +16,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.9]
         node-version: [12.x]
+        event-name: [push]
 
     steps:
     - uses: actions/checkout@v2
@@ -46,6 +49,7 @@ jobs:
     - name: Test
       run: |
         make tests
+      if: ${{ github.event_name == matrix.event-name || matrix.os == 'ubuntu-latest' }}
 
     - name: Twine check
       run: |


### PR DESCRIPTION
Only run full suite on push to `main`, else (e.g. for PR) just build and lint everywhere but only test ubuntu