### PR TITLE
Allow height to be any CSS unit

### DIFF
--- a/ipyregulartable/widget.py
+++ b/ipyregulartable/widget.py
@@ -5,6 +5,7 @@
 # This file is part of the ipyregulartable library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
+import numbers
 import numpy as np
 import pandas as pd
 from ipywidgets import DOMWidget, CallbackDispatcher
@@ -42,6 +43,13 @@ _STYLER_KEYS = (
 )
 
 
+class CSSHeight(Unicode):
+    def validate(self, obj, value):
+        if isinstance(value, numbers.Number):
+            value = f"{value}px"
+        return super().validate(obj, value)
+
+
 class RegularTableWidget(DOMWidget):
     _model_name = Unicode("RegularTableModel").tag(sync=True)
     _model_module = Unicode("ipyregulartable").tag(sync=True)
@@ -52,7 +60,7 @@ class RegularTableWidget(DOMWidget):
 
     datamodel = Instance(DataModel)
 
-    height = Integer(default_value=250).tag(sync=True)
+    height = CSSHeight(default_value="250px").tag(sync=True)
 
     css = Dict(default_value={}).tag(sync=True)
     styler = Dict(default_value={}).tag(sync=True)

--- a/ipyregulartable/widget.py
+++ b/ipyregulartable/widget.py
@@ -15,7 +15,6 @@ from traitlets import (
     Unicode,
     Dict,
     Bool,
-    Integer,
     validate,
     TraitError,
 )

--- a/js/src/model.js
+++ b/js/src/model.js
@@ -37,7 +37,7 @@ export class RegularTableModel extends DOMWidgetModel {
       _view_module: RegularTableModel.viewModule,
       _view_module_version: RegularTableModel.viewModuleVersion,
 
-      height: 200,
+      height: "250px",
       css: {
         table: "", // overall table styles
         thead: "", // header

--- a/js/src/view.js
+++ b/js/src/view.js
@@ -243,8 +243,8 @@ export class RegularTableView extends DOMWidgetView {
   }
 
   _handle_height() {
-    this.el.style.height = `${this.model.get("height")}px`;
-    this.table.style.height = `${this.model.get("height")}px`;
+    this.el.style.height = this.model.get("height");
+    this.table.style.height = this.model.get("height");
     this._handle_draw();
   }
 


### PR DESCRIPTION
...e.g. `100%` or `40vh`. Preserves the existing behaviour of assuming a number is a `px` value.